### PR TITLE
oboe.js webjar updated to 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>oboe.js</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.3-SNAPSHOT</version>
     <name>Oboe.js</name>
     <description>WebJar for Oboe.js</description>
     <url>http://webjars.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <requirejs>
             {
                 "paths": {
-                    "oboe.js": "oboe-browser.js",
-                    "oboe.js": "oboe-browser.min.js"
+                    "oboe.js":     "oboe-browser.js",
+                    "oboe.js-min": "oboe-browser.min.js"
                 }
             }
         </requirejs>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>oboe.js</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.1.3</version>
     <name>Oboe.js</name>
     <description>WebJar for Oboe.js</description>
     <url>http://webjars.org</url>
@@ -24,8 +24,8 @@
         <requirejs>
             {
                 "paths": {
-                    "oboe-js": "oboe-browser.js",
-                    "oboe-js": "oboe-browser.min.js"
+                    "oboe.js": "oboe-browser.js",
+                    "oboe.js": "oboe-browser.min.js"
                 }
             }
         </requirejs>

--- a/pom.xml
+++ b/pom.xml
@@ -11,20 +11,21 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>oboe.js</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.1.3-SNAPSHOT</version>
     <name>Oboe.js</name>
     <description>WebJar for Oboe.js</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.0.2</upstream.version>
-        <upstream.url>https://raw.githubusercontent.com/jimhigson/oboe.js/v${upstream.version}/dist</upstream.url>
+        <upstream.version>2.1.3</upstream.version>
+        <upstream.url>https://cdn.rawgit.com/jimhigson/oboe.js/v${upstream.version}/dist</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>
             {
                 "paths": {
-                    "oboe-js": "oboe-browser.js"
+                    "oboe-js": "oboe-browser.js",
+                    "oboe-js": "oboe-browser.min.js"
                 }
             }
         </requirejs>


### PR DESCRIPTION
* oboe.js webjar release set to 2.1.3-SNAPSHOT
* oboe.js updated to 2.1.3
* base path renamed to oboe.js instead of oboe-js
* now using https://raw.githubusercontent.com/jimhigson/oboe.js as download base URL
* `oboe-browser.min.js` added to the webjar

Tested OK on an internal project as follow :

```
...
<script src="{{ctx.base}}/assets/oboe.js/oboe-browser.min.js"></script>
...
```